### PR TITLE
BAH-2571 | Added option to Delete databases

### DIFF
--- a/connectmysqlrds.sh
+++ b/connectmysqlrds.sh
@@ -7,5 +7,31 @@ echo "Getting Secrets from SSM...."
 DB_HOST=$(aws ssm get-parameter --with-decryption --name "/nonprod/rds/mysql/host" --query "Parameter.Value" --output text)
 DB_USERNAME=$(aws ssm get-parameter --with-decryption --name "/$ENVIRONMENT/$APPLICATION_NAME/DB_USERNAME" --query "Parameter.Value" --output text)
 DB_PASSWORD=$(aws ssm get-parameter --with-decryption --name "/$ENVIRONMENT/$APPLICATION_NAME/DB_PASSWORD" --query "Parameter.Value" --output text)
-echo "Creating Bastion Pod...."
-kubectl run "bastion-$RANDOM" --rm -it --image alpine --env="DB_HOST=$DB_HOST" --env="DB_USERNAME=$DB_USERNAME" --env="DB_PASSWORD=$DB_PASSWORD" -- sh -c 'apk add mysql-client && mysql -h$DB_HOST -u$DB_USERNAME -p$DB_PASSWORD'
+
+echo "Please select an option:"
+echo "1. Connect to Database"
+echo "2. Delete Database"
+
+read option
+
+case $option in
+  1)
+    echo "Connecting to database.. Creating Bastion Pod..."
+    kubectl run "bastion-$RANDOM" --rm -it --image alpine --env="DB_HOST=$DB_HOST" --env="DB_USERNAME=$DB_USERNAME" --env="DB_PASSWORD=$DB_PASSWORD" -- sh -c 'apk add mysql-client && mysql -h$DB_HOST -u$DB_USERNAME -p$DB_PASSWORD'
+    ;;
+  2)
+    echo "Enter the Database Name of $APPLICATION_NAME in $ENVIRONMENT environment:"
+    read db_name
+    echo "Are you sure you want to delete $db_name? (y/n)"
+    read confirmation
+    if [ "$confirmation" == "y" ]; then
+      echo "Deleting database $db_name... Creating Bastion Pod..."
+      kubectl run "bastion-$RANDOM" --rm -it --image alpine --env="DB_HOST=$DB_HOST" --env="DB_USERNAME=$DB_USERNAME" --env="DB_PASSWORD=$DB_PASSWORD" -- sh -c "apk add mysql-client && mysql -h'$DB_HOST' -u'$DB_USERNAME' -p'$DB_PASSWORD' -e 'DROP DATABASE $db_name'"
+    else
+      echo "Aborted."
+    fi
+    ;;
+  *)
+    echo "Invalid option selected."
+    ;;
+esac


### PR DESCRIPTION
- Added an option to delete a database in our existing `connectmysqlrds.sh` shell script. 
- The script now includes the option to connect to a database or delete it. 
- When selecting the delete option, the script will ask the user to provide the database name. Although there is a way to auto-generate the db name, it may not always work for current DBs (naming is not consistent). 
- Script will also ask for a confirmation before proceeding with the deletion