### PR TITLE
BAH-2788 | Restrict Trivy report access

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -22,8 +22,8 @@ jobs:
     steps:
       - name: Setup Trivy
         run: |
-          wget https://github.com/aquasecurity/trivy/releases/download/v0.36.1/trivy_0.36.1_Linux-64bit.deb
-          sudo dpkg -i trivy_0.36.1_Linux-64bit.deb
+          wget https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_Linux-64bit.deb
+          sudo dpkg -i trivy_0.31.3_Linux-64bit.deb
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -32,7 +32,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.BAHMNI_AWS_SECRET }}
           aws-region: ${{ secrets.BAHMNI_AWS_REGION }}
           role-to-assume: ${{ secrets.BAHMNI_INFRA_ADMIN_ROLE }}
-          role-duration-seconds: 3600 # 15 mins
+          role-duration-seconds: 900 # 15 mins
           role-session-name: BahmniInfraAdminSession
       - name: Authorise Kubectl with EKS
         run: aws eks update-kubeconfig --name $CLUSTER_NAME
@@ -62,7 +62,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.BAHMNI_AWS_SECRET }}
           aws-region: ${{ secrets.BAHMNI_AWS_REGION }}
           role-to-assume: ${{ secrets.BAHMNI_INFRA_ADMIN_ROLE }}
-          role-duration-seconds: 3600 # 15 mins
+          role-duration-seconds: 900 # 15 mins
           role-session-name: BahmniInfraAdminSession
       - name: Authorise Kubectl with EKS
         run: aws eks update-kubeconfig --name $CLUSTER_NAME
@@ -85,9 +85,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Trivy
         run: |
-          wget https://github.com/aquasecurity/trivy/releases/download/v0.36.1/trivy_0.36.1_Linux-64bit.deb
-          sudo dpkg -i trivy_0.36.1_Linux-64bit.deb
-
+          wget https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_Linux-64bit.deb
+          sudo dpkg -i trivy_0.31.3_Linux-64bit.deb
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -95,7 +94,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.BAHMNI_AWS_SECRET }}
           aws-region: ${{ secrets.BAHMNI_AWS_REGION }}
           role-to-assume: ${{ secrets.BAHMNI_INFRA_ADMIN_ROLE }}
-          role-duration-seconds: 3600 # 15 mins
+          role-duration-seconds: 900 # 15 mins
           role-session-name: BahmniInfraAdminSession
       - name: Authorise Kubectl with EKS
         run: aws eks update-kubeconfig --name $CLUSTER_NAME
@@ -130,10 +129,11 @@ jobs:
     name: Upload Report
     needs: [ trivy-namespace-scan, trivy-cluster-summary-scan ]
     steps:
-      - name: Checkout reports branch
-        uses: actions/checkout@v2
+      - name: Checkout security-private repo
+        uses: actions/checkout@v3
         with:
-          ref: gh-pages
+          repository: BahmniIndiaDistro/security-private
+          token: ${{ secrets.BAHMNI_PAT }}
       - name: Download Reports
         uses: actions/download-artifact@v3
         with:
@@ -154,11 +154,11 @@ jobs:
     needs: upload-report
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout reports branch
-        uses: actions/checkout@v2
+      - name: Checkout security-private repo
+        uses: actions/checkout@v3
         with:
-          ref: gh-pages
-      
+          repository: BahmniIndiaDistro/security-private
+          token: ${{ secrets.BAHMNI_PAT }}     
       - name: Download Cluster Summary
         uses: actions/download-artifact@v3
         with:
@@ -182,4 +182,4 @@ jobs:
     steps:
       - name: Post message
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"text":"🔎 Trivy Security Scan completed for ${{ env.CLUSTER_NAME }}. \n> <https://bahmniindiadistro.github.io/helm-umbrella-chart/trivy-reports/|View Report>"}' ${{ secrets.SLACK_WEBHOOK_URL }}
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"🔎 Trivy Security Scan completed for ${{ env.CLUSTER_NAME }}. \n> <https://github.com/BahmniIndiaDistro/security-private/|View Report [Private Repository]>"}' ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -104,7 +104,7 @@ jobs:
         run: mkdir reports
 
       - name: Run Trivy Detailed Scan for Critical Vulnerabilities
-        run: trivy k8s --severity CRITICAL --report=all --namespace ${{ matrix.namespaces }} --timeout=1h all -o reports/critical-vulnerabilities.txt
+        run: trivy k8s --no-progress --severity CRITICAL --report=all --namespace ${{ matrix.namespaces }} --timeout=1h all -o reports/critical-vulnerabilities.txt
       - name: Run Trivy Detailed Scan for High Vulnerabilities
         run: trivy k8s --no-progress --severity HIGH --report=all --namespace ${{ matrix.namespaces }} --timeout=1h all -o reports/high-vulnerabilities.txt
       - name: Run Trivy Detailed Scan for Medium Vulnerabilities

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -104,7 +104,7 @@ jobs:
         run: mkdir reports
 
       - name: Run Trivy Detailed Scan for Critical Vulnerabilities
-        run: trivy k8s --no-progress --severity CRITICAL --report=all --namespace ${{ matrix.namespaces }} --timeout=1h all -o reports/critical-vulnerabilities.txt
+        run: trivy k8s --severity CRITICAL --report=all --namespace ${{ matrix.namespaces }} --timeout=1h all -o reports/critical-vulnerabilities.txt
       - name: Run Trivy Detailed Scan for High Vulnerabilities
         run: trivy k8s --no-progress --severity HIGH --report=all --namespace ${{ matrix.namespaces }} --timeout=1h all -o reports/high-vulnerabilities.txt
       - name: Run Trivy Detailed Scan for Medium Vulnerabilities

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - BAH-2788
     paths:
       - .github/workflows/trivy-scan.yaml
   schedule:

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -21,8 +21,9 @@ jobs:
     steps:
       - name: Setup Trivy
         run: |
-          wget https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_Linux-64bit.deb
-          sudo dpkg -i trivy_0.31.3_Linux-64bit.deb
+          wget https://github.com/aquasecurity/trivy/releases/download/v0.36.1/trivy_0.36.1_Linux-64bit.deb
+          sudo dpkg -i trivy_0.36.1_Linux-64bit.deb
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -83,8 +84,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Trivy
         run: |
-          wget https://github.com/aquasecurity/trivy/releases/download/v0.31.3/trivy_0.31.3_Linux-64bit.deb
-          sudo dpkg -i trivy_0.31.3_Linux-64bit.deb
+          wget https://github.com/aquasecurity/trivy/releases/download/v0.36.1/trivy_0.36.1_Linux-64bit.deb
+          sudo dpkg -i trivy_0.36.1_Linux-64bit.deb
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -32,7 +32,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.BAHMNI_AWS_SECRET }}
           aws-region: ${{ secrets.BAHMNI_AWS_REGION }}
           role-to-assume: ${{ secrets.BAHMNI_INFRA_ADMIN_ROLE }}
-          role-duration-seconds: 900 # 15 mins
+          role-duration-seconds: 3600 # 15 mins
           role-session-name: BahmniInfraAdminSession
       - name: Authorise Kubectl with EKS
         run: aws eks update-kubeconfig --name $CLUSTER_NAME
@@ -62,7 +62,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.BAHMNI_AWS_SECRET }}
           aws-region: ${{ secrets.BAHMNI_AWS_REGION }}
           role-to-assume: ${{ secrets.BAHMNI_INFRA_ADMIN_ROLE }}
-          role-duration-seconds: 900 # 15 mins
+          role-duration-seconds: 3600 # 15 mins
           role-session-name: BahmniInfraAdminSession
       - name: Authorise Kubectl with EKS
         run: aws eks update-kubeconfig --name $CLUSTER_NAME
@@ -95,7 +95,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.BAHMNI_AWS_SECRET }}
           aws-region: ${{ secrets.BAHMNI_AWS_REGION }}
           role-to-assume: ${{ secrets.BAHMNI_INFRA_ADMIN_ROLE }}
-          role-duration-seconds: 900 # 15 mins
+          role-duration-seconds: 3600 # 15 mins
           role-session-name: BahmniInfraAdminSession
       - name: Authorise Kubectl with EKS
         run: aws eks update-kubeconfig --name $CLUSTER_NAME

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - BAH-2788
     paths:
       - .github/workflows/trivy-scan.yaml
   schedule:


### PR DESCRIPTION
This PR updates the current trivy scan workflow to push the report generated to the [security-private](https://github.com/BahmniIndiaDistro/security-private) repository instead of pushing to the gh-pages branch. This will provide better security for the scan reports as they will not be publicly accessible. Additionally, it updates the slack notify message and URL to provide more relevant information about the scan results and make it easier for team members to access the reports.