### PR TITLE
[Rahul] | BAH-3635 | Add. Config For Lucene Match Type

### DIFF
--- a/values/demo.yaml
+++ b/values/demo.yaml
@@ -13,6 +13,8 @@ metadata:
 
 openmrs:
   enabled: true
+  config:
+    LUCENE_MATCH_TYPE: "START"
   metadata:
     labels:
       environment: demo

--- a/values/dev.yaml
+++ b/values/dev.yaml
@@ -13,6 +13,8 @@ metadata:
 
 openmrs:
   enabled: true
+  config:
+    LUCENE_MATCH_TYPE: "START"
 bahmni-web:
   enabled: true
 bahmni-lab:

--- a/values/local.yaml
+++ b/values/local.yaml
@@ -20,6 +20,7 @@ openmrs:
     OMRS_DB_NAME: openmrs
     DEBUG: true
     OMRS_CREATE_TABLES: true
+    LUCENE_MATCH_TYPE: "START"
 bahmni-web:
   enabled: true
 bahmni-lab:

--- a/values/performance.yaml
+++ b/values/performance.yaml
@@ -22,6 +22,7 @@ openmrs:
     OMRS_JAVA_SERVER_OPTS: '-Dfile.encoding=UTF-8 -server -Xms1024m -Xmx4096m -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1NewSizePercent=25 -XX:G1MaxNewSizePercent=50 -XX:SurvivorRatio=8 -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m -XX:CompressedClassSpaceSize=256m -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./java.hprof -Xloggc:/usr/local/tomcat/logs/gc.log -XX:+UseStringDeduplication -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -agentpath:/etc/profiling/YourKit-JavaProfiler-2022.9/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all -javaagent:/etc/jvm_metrics/jmx_prometheus_javaagent.jar=8280:/etc/jvm_metrics/config.yml'
     OMRS_JAVA_MEMORY_OPTS: ''
     OMRS_MODULE_WEB_ADMIN: true
+    LUCENE_MATCH_TYPE: "START"
 bahmni-web:
   enabled: true
   metadata:

--- a/values/qa.yaml
+++ b/values/qa.yaml
@@ -13,6 +13,8 @@ metadata:
 
 openmrs:
   enabled: true
+  config:
+    LUCENE_MATCH_TYPE: "START"
   metadata:
     labels:
       environment: qa


### PR DESCRIPTION
JIRA -> [BAH-3635](https://bahmni.atlassian.net/browse/BAH-3635)

In this pull request, the Lucene search functionality has undergone configuration enhancements. Now, the search results vary based on the `LUCENE_MATCH_TYPE` environment variable, providing distinct outcomes for different match types:

**`EXACT`** : Only exact matches will be considered.
**`START`** : Matches that commence with the search term will be considered.
**`ANYWHERE`** : All search results containing the search term anywhere in the text will be considered.


| LUCENE_MATCH_TYPE | Search Term | Daniel  | Nielsen  |
| -----------------------  | ------------- | ------  |-------- |
| EXACT             | Daniel       | True   | False  |
|                          | Nielsen     | False  | True   | 
| START              | Niel           | False  | True   | 
|                          | niel            | False  | True   | 
| ANYWHERE     | Niel           | True   | True   |
|                           | niel           | True   | True   |