### PR TITLE
BAH-4117 | Add. Environment for ABDM V3 

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,7 @@ on:
         default: dev
         options:
           - dev
+          - abdmv3
           - qa
           - demo
           - performance

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -101,6 +101,7 @@ spec:
                   number: 80
          {{- end }}
 
+    {{- if .Values.crater.enabled }}
     - host: payments-{{ .Values.ingress.host }}
       http:
         paths:
@@ -113,6 +114,7 @@ spec:
                 port:
                   number: 80
           {{- end }}
+    {{- end }}
 ---
 
 apiVersion: networking.k8s.io/v1

--- a/values/abdmv3.yaml
+++ b/values/abdmv3.yaml
@@ -63,6 +63,8 @@ otp-service:
     CONNECTION_STRING: "Host=bahmni-abdmv3-postgresql;Port=5432;Username=postgres;Password=welcome;Database=otpservice;"
 hip-atomfeed:
   enabled: true
+  config:
+    DATABASE_URL: "jdbc:postgresql://bahmni-qa-postgresql:5432/"
 
 postgresql:
   enabled: true

--- a/values/abdmv3.yaml
+++ b/values/abdmv3.yaml
@@ -54,6 +54,8 @@ hiu-ui:
     RABBITMQ_HOST: bahmni-abdmv3-rabbitmq
 hip:
   enabled: true
+  image:
+    tag: "v3"
   config:
     CONNECTION_STRING: "Host=bahmni-abdmv3-postgresql;Port=5432;Username=postgres;Password=welcome;Database=hipservice"
     RABBITMQ_HOST: "bahmni-abdmv3-rabbitmq"
@@ -114,6 +116,8 @@ implementer-interface:
 
 abha-verification:
   enabled: true
+  image:
+    tag: "v3"
 
 bahmni-metabase:
   enabled: false

--- a/values/abdmv3.yaml
+++ b/values/abdmv3.yaml
@@ -59,6 +59,8 @@ hip:
     BAHMNI_ID: "Bahmni"
 otp-service:
   enabled: true
+  config:
+    CONNECTION_STRING: "Host=bahmni-abdmv3-postgresql;Port=5432;Username=postgres;Password=welcome;Database=otpservice;"
 hip-atomfeed:
   enabled: true
 

--- a/values/abdmv3.yaml
+++ b/values/abdmv3.yaml
@@ -15,6 +15,7 @@ openmrs:
   enabled: true
   config:
     LUCENE_MATCH_TYPE: "START"
+    OMRS_C3P0_MAX_SIZE: 20
 bahmni-web:
   enabled: true
 bahmni-lab:

--- a/values/abdmv3.yaml
+++ b/values/abdmv3.yaml
@@ -1,0 +1,130 @@
+global:
+  storageClass: bahmni-efs-sc
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: nonprod
+  TZ: "Asia/Kolkata"
+
+metadata:
+  labels:
+    environment: abdmv3
+  ingress:
+    PROXY_BODY_SIZE: "7m"
+    ABDM_PROXY_BODY_SIZE: "30m"
+
+openmrs:
+  enabled: true
+  config:
+    LUCENE_MATCH_TYPE: "START"
+bahmni-web:
+  enabled: true
+bahmni-lab:
+  enabled: false
+crater:
+  enabled: false
+  config:
+    AUTO_INSTALL: "true"
+    ADMIN_NAME: Super Man
+    COMPANY_NAME: Bahmni
+    COMPANY_SLUG: bahmni
+    COUNTRY_ID: 101
+    CRATER_DEFAULT_CURRENCY: INR
+  secrets:
+    ADMIN_EMAIL: "superman@bahmni.org"
+reports:
+  enabled: false
+  config:
+    OPENMRS_HOST: "openmrs"
+hiu:
+  enabled: true
+  config:
+    POSTGRES_HOST: "bahmni-abdmv3-postgresql"
+    RABBITMQ_HOST: "bahmni-abdmv3-rabbitmq"
+    HIU_ID: "Bahmni"
+    HIU_NAME: "Bahmni"
+
+hiu-db:
+  enabled: true
+  config:
+    JAVA_TOOL_OPTIONS: "-Djdbc.url=jdbc:postgresql://bahmni-abdmv3-postgresql:5432/ -Djdbc.username=postgres -Djdbc.password=welcome -Djdbc.database=health_information_user"
+hiu-ui:
+  enabled: true
+  config:
+    POSTGRES_HOST: bahmni-abdmv3-postgresql
+    RABBITMQ_HOST: bahmni-abdmv3-rabbitmq
+hip:
+  enabled: true
+  config:
+    CONNECTION_STRING: "Host=bahmni-abdmv3-postgresql;Port=5432;Username=postgres;Password=welcome;Database=hipservice"
+    RABBITMQ_HOST: "bahmni-abdmv3-rabbitmq"
+    BAHMNI_ID: "Bahmni"
+otp-service:
+  enabled: true
+hip-atomfeed:
+  enabled: true
+
+postgresql:
+  enabled: true
+  volumePermissions:
+    enabled: true
+  primary:
+    persistence:
+      subPath: abdmv3
+      storageClass: bahmni-efs-sc
+      accessModes:
+        - ReadWriteMany
+    nodeSelector:
+      eks.amazonaws.com/nodegroup: nonprod
+  image:
+    tag: 14-debian-11
+
+rabbitmq:
+  enabled: true
+  auth:
+    erlangCookie: bahmni
+  persistence:
+    storageClass: bahmni-efs-sc
+    accessModes:
+      - ReadWriteMany
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: nonprod
+  image:
+    repository: rabbitmq
+    tag: alpine
+
+patient-documents:
+  enabled: true
+  config:
+    OPENMRS_HOST: "openmrs"
+
+crater-atomfeed:
+  enabled: false
+  metadata:
+    labels:
+      environment: abdmv3
+appointments:
+  enabled: true
+
+implementer-interface:
+  enabled: false
+
+abha-verification:
+  enabled: true
+
+bahmni-metabase:
+  enabled: false
+  config:
+    MB_DB_TYPE: postgres
+    MB_DB_DBNAME: 'metabase'
+    MB_DB_PORT:  5432
+    MART_DB_NAME: martdb
+  secrets:
+    MB_ADMIN_FIRST_NAME: 'Admin'
+    MB_DB_HOST: 'bahmni-abdmv3-postgresql'
+    MART_DB_HOST: 'bahmni-abdmv3-postgresql'
+
+bahmni-mart:
+  enabled: false
+  config:
+    MART_DB_NAME: martdb
+  secrets:
+    MART_DB_HOST: "bahmni-abdmv3-postgresql"

--- a/values/abdmv3.yaml
+++ b/values/abdmv3.yaml
@@ -64,7 +64,7 @@ otp-service:
 hip-atomfeed:
   enabled: true
   config:
-    DATABASE_URL: "jdbc:postgresql://bahmni-qa-postgresql:5432/"
+    DATABASE_URL: "jdbc:postgresql://bahmni-abdmv3-postgresql:5432/"
 
 postgresql:
   enabled: true

--- a/values/abdmv3.yaml
+++ b/values/abdmv3.yaml
@@ -31,7 +31,7 @@ crater:
   secrets:
     ADMIN_EMAIL: "superman@bahmni.org"
 reports:
-  enabled: false
+  enabled: true
   config:
     OPENMRS_HOST: "openmrs"
 hiu:

--- a/values/dev.yaml
+++ b/values/dev.yaml
@@ -15,6 +15,7 @@ openmrs:
   enabled: true
   config:
     LUCENE_MATCH_TYPE: "START"
+    OMRS_C3P0_MAX_SIZE: 20
 bahmni-web:
   enabled: true
 bahmni-lab:


### PR DESCRIPTION
This PR adds the required configuration to deploy a new environment for ABDM v3. The environment is going to be a temporary environment with limited application running. Only EMR and ABDM components will be run